### PR TITLE
fix https://github.com/hosso/notion-custom-domain/issues/17

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ app.use(
       return headers;
     },
     userResDecorator: (_proxyRes, proxyResData, userReq) => {
-      if (/^\/app-.*\.js$/.test(userReq.url)) {
+      if (/.?\/app-.*\.js$/.test(userReq.url)) {
         return proxyResData
           .toString()
           .replace(/^/, ncd)


### PR DESCRIPTION
fix https://github.com/hosso/notion-custom-domain/issues/17
Now it will match both `*/app-*.js` and `/app-*.js`. Although we can also use `^(\/_assets\/app-|\/app-).*\.js$`, but I'm not sure if Notion will change it in the future. Using this method should be better (since it won't affect other cases, so this one is the easiest XD).

![f28ccda2710ab95025fc7d501c24f3b5](https://github.com/hosso/notion-custom-domain/assets/45081750/6d3394ce-be65-47ff-8026-705aaf92e7bb)
