### PR TITLE
fix https zstd ERR_CONTENT_DECODING_FAILED

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,12 @@ const app = express();
 
 app.use(
   proxy(pageDomain, {
+    proxyReqOptDecorator: (proxyReqOpts, srcReq) => {
+      if (proxyReqOpts.headers) {
+        delete proxyReqOpts.headers['accept-encoding'];
+      }
+      return proxyReqOpts;
+    },
     filter: (req, res) => {
       // Pseudo endpoint returning 200
       if (/^\/200\/?/.test(req.url)) {


### PR DESCRIPTION
Recently, two of my websites encountered an issue where certain .js files failed to load, causing the sites to break.   

Your website has also encountered this issue



After debugging, I found:

- HTTP Request includes only `gzip`, `deflate` in `Accept-Encoding`

- HTTPS Request adds `br`, `zstd` to `Accept-Encoding`

For HTTPS requests, the server returns `Content-Encoding`: `zstd`, I think that is the reason

I have tried to fix this issue, and you can check it on [blog.youngmoe.com](https://blog.youngmoe.com)


<details>

<summary> detail </summary>

![image](https://github.com/user-attachments/assets/b3a9966d-1935-420f-b774-66f887a25b57)
![Image](https://github.com/user-attachments/assets/a9bb01f6-9b1d-4455-a11e-1140b30a0262)

![Image](https://github.com/user-attachments/assets/291fe4ad-7318-416d-b214-fedfe9dac2fa)

![Image](https://github.com/user-attachments/assets/7471492d-0744-46d5-892f-0450427648f9)

![Image](https://github.com/user-attachments/assets/f5fec30d-5c85-4586-90dc-da9f32a10b37)
</details>



