### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install dependencies:
 yarn
 ```
 
-Then deploy to Vercel with specifiying your public Notion page:
+Then deploy to Vercel with specifying your public Notion page:
 
 ```
 PAGE_URL=https://<your-domain>.notion.site/<Your-Page-ID> \


### PR DESCRIPTION
## Summary
- fix spelling in deployment instructions

## Testing
- `npm run format-check`


------
https://chatgpt.com/codex/tasks/task_e_689f52e1ea0c832dbc9a5345c2232d49