### PR TITLE
fix typo in window.location comment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,7 @@ app.use(
         data = data.replace(
           /window\.location\.href(?=[^=]|={2,})/g,
           'ncd.href()',
-        ); // Exclude 'window.locaton.href=' but not 'window.locaton.href=='
+        ); // Exclude 'window.location.href=' but not 'window.location.href=='
       } else {
         // Assume HTML
         data = data


### PR DESCRIPTION
## Summary
- fix typo in comment describing `window.location.href`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run format-check`


------
https://chatgpt.com/codex/tasks/task_e_689f57453280832da0d5542ce4b85ba6